### PR TITLE
Segfault when specifying empty where condition

### DIFF
--- a/src/phrases/conditionalphrase.cpp
+++ b/src/phrases/conditionalphrase.cpp
@@ -112,7 +112,8 @@ ConditionalPhrase::~ConditionalPhrase()
 ConditionalPhrase &ConditionalPhrase::operator =(const ConditionalPhrase &other)
 {
     data = other.data;
-    data->parents++;
+    if (data)
+        data->parents++;
     return *this;
 }
 

--- a/src/phrases/conditionalphrase.h
+++ b/src/phrases/conditionalphrase.h
@@ -36,7 +36,7 @@ ConditionalPhrase operator op(const QVariant &other) \
 class NUT_EXPORT ConditionalPhrase
 {
 public:
-    PhraseData *data;
+    PhraseData *data = nullptr;
 //    QSharedPointer<PhraseData> leftDataPointer;
 //    QSharedPointer<PhraseData> rightDataPointer;
     ConditionalPhrase();


### PR DESCRIPTION
When specifying empty condition in the where condition the code pointed to uninitialized memory in the conditionalphrase.cpp 115 line. This PR fixes this issue.

It might be also useful to add an example to the examples / tests for clearing the where condition. (I needed to use it for filtering a model.)