### PR TITLE
Set ordered config in the pro file

### DIFF
--- a/nut.pro
+++ b/nut.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-
+CONFIG += ordered
 SUBDIRS += \
     src \
     test


### PR DESCRIPTION
When building the nut.pro (with multiple threads) it was possible to have a build failure until the library have not built. 
The CONFIG += ordered line solves this problem:

> When using the subdirs template, this option specifies that the directories listed should be processed in the order in which they are given.

https://doc.qt.io/qt-5/qmake-variable-reference.html