### PR TITLE
Use SQLite for testing on Linux

### DIFF
--- a/test/common/consts.h
+++ b/test/common/consts.h
@@ -12,12 +12,20 @@
     .arg(timer.elapsed() / 1000.) \
     .arg(__func__)
 
+#ifdef Q_OS_LINUX
+#define DRIVER "QSQLITE"
+#define DATABASE QStringLiteral("/tmp/testdb.sqlite")
+#define HOST QString()
+#define USERNAME QString()
+#define PASSWORD QString()
+#else
 #define DRIVER "QODBC"
 #define DATABASE QString("DRIVER={SQL Server};Server=.;Database=%1;Uid=sa;Port=1433;Pwd=qwe123!@#;WSID=.") \
     .arg(QString("nut_test_%1_db").arg(metaObject()->className()).toLower())
 #define HOST "127.0.0.1"
 #define USERNAME "sa"
 #define PASSWORD "qwe123!@#"
+#endif
 
 #ifdef Q_OS_LINUX
 #   define OS "Linux"

--- a/test/tst_basic/tst_basic.cpp
+++ b/test/tst_basic/tst_basic.cpp
@@ -148,7 +148,7 @@ void BasicTest::selectPosts()
 {
     auto q = db.posts()->query()
         ->join<Comment>()
-        ->orderBy(!Post::saveDateField() | Post::bodyField())
+        ->orderBy((!Post::saveDateField()) | Post::bodyField())
         ->setWhere(Post::idField() == postId);
 
     auto posts = q->toList();


### PR DESCRIPTION
- Use SQLite for testing on Linux
- Fix clang warning about parentheses

Running tests on Linux works OOB now (once #63  got merged). (SQLite creates the database file automatically if not exists.)