### PR TITLE
Fix Query::first

### DIFF
--- a/src/generators/mysqlgenerator.cpp
+++ b/src/generators/mysqlgenerator.cpp
@@ -345,4 +345,15 @@ QString MySqlGenerator::createConditionalPhrase(const PhraseData *d) const
     return SqlGeneratorBase::createConditionalPhrase(d);
 }
 
+void MySqlGenerator::appendSkipTake(QString &sql, int skip, int take)
+{
+    if (take > 0 && skip > 0) {
+        sql.append(QString(" LIMIT %1 OFFSET %2")
+                   .arg(take)
+                   .arg(skip));
+    } else if (take > 0) {
+        sql.append(QString(" LIMIT %1").arg(take));
+    }
+}
+
 NUT_END_NAMESPACE

--- a/src/generators/mysqlgenerator.h
+++ b/src/generators/mysqlgenerator.h
@@ -37,6 +37,8 @@ public:
 //    QString phrase(const PhraseData *d) const;
     //    QString selectCommand(AgregateType t, QString agregateArg, QString tableName, QList<WherePhrase> &wheres, QList<WherePhrase> &orders, QList<RelationModel *> joins, int skip, int take);
     QString createConditionalPhrase(const PhraseData *d) const override;
+    void appendSkipTake(QString &sql, int skip, int take) override;
+
 private:
     bool readInsideParentese(QString &text, QString &out);
 };

--- a/src/generators/sqlgeneratorbase.cpp
+++ b/src/generators/sqlgeneratorbase.cpp
@@ -617,8 +617,6 @@ QString SqlGeneratorBase::selectCommand(const QString &tableName,
                                         const int skip,
                                         const int take)
 {
-    Q_UNUSED(skip);
-    Q_UNUSED(take);
     QStringList joinedOrders;
     QString selectText = agregateText(t, agregateArg);
     QString whereText = createConditionalPhrase(where.data);

--- a/src/generators/sqlitegenerator.cpp
+++ b/src/generators/sqlitegenerator.cpp
@@ -187,10 +187,13 @@ QStringList SqliteGenerator::diff(TableModel *oldTable, TableModel *newTable)
 }
 void SqliteGenerator::appendSkipTake(QString &sql, int skip, int take)
 {
-    if (take != -1 && skip != -1)
+    if (take > 0 && skip > 0) {
         sql.append(QString(" LIMIT %1 OFFSET %2")
-                       .arg(take)
+                   .arg(take)
                    .arg(skip));
+    } else if (take > 0) {
+        sql.append(QString(" LIMIT %1").arg(take));
+    }
 }
 
 QString SqliteGenerator::primaryKeyConstraint(const TableModel *table) const

--- a/src/query.h
+++ b/src/query.h
@@ -169,14 +169,13 @@ Q_OUTOFLINE_TEMPLATE Query<T>::~Query()
 template <class T>
 Q_OUTOFLINE_TEMPLATE RowList<T> Query<T>::toList(int count)
 {
-    Q_UNUSED(count);
     Q_D(Query);
     RowList<T> returnList;
     d->select = "*";
 
     d->sql = d->database->sqlGenertor()->selectCommand(
                 d->tableName, d->fieldPhrase, d->wherePhrase, d->orderPhrase,
-                d->relations, d->skip, d->take);
+                d->relations, d->skip, count);
 
     QSqlQuery q = d->database->exec(d->sql);
     if (q.lastError().isValid()) {
@@ -372,7 +371,6 @@ template <class T>
 Q_OUTOFLINE_TEMPLATE Row<T> Query<T>::first()
 {
     skip(0);
-    take(1);
     RowList<T> list = toList(1);
 
     if (list.count())

--- a/test/tst_basic/tst_basic.cpp
+++ b/test/tst_basic/tst_basic.cpp
@@ -225,6 +225,12 @@ void BasicTest::testDate()
     QTEST_ASSERT(q->saveDate() == d);
 }
 
+void BasicTest::testLimitedQuery()
+{
+    auto comments = db.comments()->query()->toList(2);
+    QTEST_ASSERT(comments.length() == 2);
+}
+
 void BasicTest::join()
 {
 //    TIC();

--- a/test/tst_basic/tst_basic.h
+++ b/test/tst_basic/tst_basic.h
@@ -36,6 +36,7 @@ private slots:
     void selectPostIds();
     void updatePostOnTheFly();
     void testDate();
+    void testLimitedQuery();
     void selectWithInvalidRelation();
     void modifyPost();
     void emptyDatabase();


### PR DESCRIPTION
The Query::first fetched all records. Now the limit number is properly
propagated to the SQL generators. Also fixed various Limit and Offset related issues:

- Optimized limited but not offseted queries in SqliteGenerator
- Implemented limit and offset generation in the MySqlGenerator
- Added test for limited data query