### PR TITLE
Remove semicolons after Q_UNUSED macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 *.qbs.user
 *.qbs.user.*
 *.moc
+moc_*.h
 moc_*.cpp
 qrc_*.cpp
 ui_*.h
@@ -34,3 +35,6 @@ Makefile*
 *.qmlproject.user.*
 
 build
+
+# KDE show hidden folder marker
+.directory

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,16 @@ build
 
 # KDE show hidden folder marker
 .directory
+
+
+# built tests executables
+test/tst_basic/tst_basic*
+test/tst_benckmark/tst_benchmark*
+test/tst_datatypes/tst_datatypes*
+test/tst_datetime/tst_datetime*
+test/tst_generators/target_wrapper.sh
+test/tst_generators/tst_generators*
+test/tst_json/tst_upgrades*
+test/tst_phrases/tst_phrases*
+test/tst_quuid/tst_uuid*
+test/tst_upgrades/tst_upgrades*

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -525,8 +525,8 @@ void Database::databaseCreated()
 
 void Database::databaseUpdated(int oldVersion, int newVersion)
 {
-    Q_UNUSED(oldVersion);
-    Q_UNUSED(newVersion);
+    Q_UNUSED(oldVersion)
+    Q_UNUSED(newVersion)
 }
 
 

--- a/src/generators/sqlgeneratorbase.cpp
+++ b/src/generators/sqlgeneratorbase.cpp
@@ -78,7 +78,7 @@ SqlGeneratorBase::SqlGeneratorBase(Database *parent)
 
 QString SqlGeneratorBase::masterDatabaseName(QString databaseName)
 {
-    Q_UNUSED(databaseName);
+    Q_UNUSED(databaseName)
     return QString();
 }
 
@@ -152,7 +152,7 @@ QString SqlGeneratorBase::fieldDeclare(FieldModel *field)
 
 QStringList SqlGeneratorBase::constraints(TableModel *table)
 {
-    Q_UNUSED(table);
+    Q_UNUSED(table)
     return QStringList();
 }
 
@@ -569,8 +569,8 @@ QString SqlGeneratorBase::selectCommand(const QString &tableName,
                                         const int skip,
                                         const int take)
 {
-    Q_UNUSED(skip);
-    Q_UNUSED(take);
+    Q_UNUSED(skip)
+    Q_UNUSED(take)
     QString selectText;
 
     if (fields.data.count() == 0) {
@@ -712,8 +712,8 @@ QString SqlGeneratorBase::insertCommand(const QString &tableName, const Assignme
 //                                        QList<RelationModel*> joins,
 //                                        int skip, int take)
 //{
-//    Q_UNUSED(take);
-//    Q_UNUSED(skip);
+//    Q_UNUSED(take)
+//    Q_UNUSED(skip)
 
 //    QStringList joinedOrders;
 //    QString select = agregateText(t, agregateArg);
@@ -979,9 +979,9 @@ SqlGeneratorBase::operatorString(const PhraseData::Condition &cond) const
 
 void SqlGeneratorBase::appendSkipTake(QString &sql, int skip, int take)
 {
-    Q_UNUSED(sql);
-    Q_UNUSED(skip);
-    Q_UNUSED(take);
+    Q_UNUSED(sql)
+    Q_UNUSED(skip)
+    Q_UNUSED(take)
 }
 
 QString SqlGeneratorBase::primaryKeyConstraint(const TableModel *table) const

--- a/src/generators/sqlitegenerator.cpp
+++ b/src/generators/sqlitegenerator.cpp
@@ -198,7 +198,7 @@ void SqliteGenerator::appendSkipTake(QString &sql, int skip, int take)
 
 QString SqliteGenerator::primaryKeyConstraint(const TableModel *table) const
 {
-    Q_UNUSED(table);
+    Q_UNUSED(table)
     return QString();
 //    QString sql = QString("CONSTRAINT pk_%1 PRIMARY KEY (%2)")
 //            .arg(table->name())

--- a/src/sqlmodel.cpp
+++ b/src/sqlmodel.cpp
@@ -52,13 +52,13 @@ SqlModel::SqlModel(Database *database, TableSetBase *tableSet, QObject *parent) 
 
 int SqlModel::rowCount(const QModelIndex &parent) const
 {
-    Q_UNUSED(parent);
+    Q_UNUSED(parent)
     return d->rows.count();
 }
 
 int SqlModel::columnCount(const QModelIndex &parent) const
 {
-    Q_UNUSED(parent);
+    Q_UNUSED(parent)
     return d->model->fields().count();
 }
 


### PR DESCRIPTION
The Q_UNUSED macro is defined as:
`#define Q_UNUSED(x) (void)x;`
so no semicolon is required after that. (This could trigger warnings with clang-tidy).
This PR removes these unnecessary semicolons.
