### PR TITLE
Fix qVariantFromValue deprecation

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -187,7 +187,7 @@ inline bool nutClassInfo(const QMetaClassInfo &classInfo,
 
     type = parts[0];
     name = parts[1];
-    value = qVariantFromValue(parts[2]);
+    value = QVariant::fromValue(parts[2]);
     return true;
 }
 


### PR DESCRIPTION
Since Qt 5.14 the qVariantFromValue is being obsolete, I have replaced the calls with QVariant::fromValue which is equivalent to it.