### PR TITLE
Added warning about not cloned submodule

### DIFF
--- a/nut.pri
+++ b/nut.pri
@@ -4,6 +4,11 @@ CONFIG += c++11
 
 INCLUDEPATH += $$PWD/include
 DEFINES += NUT_SHARED_POINTER
+
+!exists(3rdparty/serializer/src/src.pri) {
+    error("Please do git submodule update --init --recursive in the Nut directory")
+}
+
 include(3rdparty/serializer/src/src.pri)
 
 HEADERS += \


### PR DESCRIPTION
This PR adds a check to the nut.pri file to warn about the uncloned submodule (in our case the serializer)